### PR TITLE
Allow specifying minimap2 params in config

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -9,6 +9,7 @@
   variants, but should not eliminate haplotypic variation in an assembly that is not separated into two FASTA files.
 * chrom_cluster [False]
 * sample_delimiter [_]: For extracting sample from assembly name ("{sample}" wildcard in input path patterns). May be one of "_", ".", "-", "+", "#".
+* minimap2_params [-x asm20 -m 10000 -z 10000,50 -r 50000 --end-bonus=100 -O 5,56 -E 4,1 -B 5]: Alignment parameters used to run minimap2
 
 ## Call
 

--- a/rules/align.snakefile
+++ b/rules/align.snakefile
@@ -135,7 +135,8 @@ rule align_map:
         sam=temp('temp/{asm_name}/align/pre-cut/aligned_tig_{hap}.sam.gz')
     params:
         cpu=lambda wildcards: _align_map_cpu(wildcards, get_config(wildcards)),
-        aligner=lambda wildcards: get_config(wildcards, 'aligner', 'minimap2')
+        aligner=lambda wildcards: get_config(wildcards, 'aligner', 'minimap2'),
+        minimap2_params=lambda wildcards: get_config(wildcards, 'minimap2_params', '-x asm20 -m 10000 -z 10000,50 -r 50000 --end-bonus=100 -O 5,56 -E 4,1 -B 5')
     run:
 
         # Get aligner
@@ -155,9 +156,8 @@ rule align_map:
             if aligner == 'minimap2':
                 shell(
                     """minimap2 """
-                        """-x asm20 -m 10000 -z 10000,50 -r 50000 --end-bonus=100 """
+                        """{params.minimap2_params} """
                         """--secondary=no -a -t {params.cpu} --eqx -Y """
-                        """-O 5,56 -E 4,1 -B 5 """
                         """{input.ref_fa} {input.fa} | """
                         """awk -vOFS="\\t" '($1 !~ /^@/) {{$10 = "*"; $11 = "*"}} {{print}}' | """
                         """gzip > {output.sam}"""


### PR DESCRIPTION
This commit allows the user to specify minimap2 alignment parameters in
the configuration file in order to override the defaults, which work
best for humans. Fixes #19.